### PR TITLE
fixed the message saving in mongoDb

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,13 +1,13 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "description": "",
   "license": "ISC",
   "author": "",
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "dependencies": {
@@ -20,5 +20,7 @@
     "multer": "^2.0.1",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1"
-  }
+  },
+  "devDependencies": {},
+  "description": ""
 }


### PR DESCRIPTION
This PR ensures that all chat messages are persistently stored in MongoDB Atlas, in addition to being delivered via real-time Socket.IO. Previously, messages were only exchanged in real time, and were lost on page refresh due to the lack of backend storage.

✅ Changes Made
✅ Integrated a POST /api/messages API call in the frontend to persist messages to the database.

✅ Preserved real-time delivery using socket.emit after successful API response.

✅ Enhanced sendMessage() function in the frontend (ConnectionDetail.tsx) to:

Call the backend API using axios

Pass proper JWT token for authentication

Maintain UI state update and Socket.IO emit logic